### PR TITLE
Fix decord frame handling for numpy outputs

### DIFF
--- a/run_gr00t_distill_decoder_input.py
+++ b/run_gr00t_distill_decoder_input.py
@@ -118,7 +118,7 @@ class VideoFrameReader:
         if _HAS_DECORD:
             try:
                 import decord
-                decord.bridge.set_bridge("native")
+                decord.bridge.set_bridge("numpy")
             except Exception:
                 pass
             self._vr = decord.VideoReader(video_path)
@@ -155,7 +155,10 @@ class VideoFrameReader:
 
         if _HAS_DECORD:
             img = self._vr[frame_idx]
-            return img
+            try:
+                return img.asnumpy()
+            except AttributeError:
+                return np.asarray(img)
         elif _HAS_OPENCV:
             self._cap.set(cv2.CAP_PROP_POS_FRAMES, frame_idx)
             ok, frame_bgr = self._cap.read()


### PR DESCRIPTION
## Summary
- configure the Decord bridge to emit numpy arrays when available
- convert Decord frames to numpy arrays before returning them from `VideoFrameReader`

## Testing
- python3 run_gr00t_distill_decoder_input.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e5f433e22083318729478289f6b39a